### PR TITLE
fix(footer): define background para evitar fundo preto inesperado e usa Link e Image do Next para seguir boas praticas

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,7 +33,7 @@ export default function RootLayout({
       </head>
       <body>
         {children}
-        <footer className="py-12 text-center bg-foreground">
+        <footer className="py-12 text-center bg-background">
           <div className="flex flex-col items-center gap-4 text-gray-500 text-sm">
             <p className="flex items-center gap-2">
               <Heart size={16} className="text-red-400" />


### PR DESCRIPTION
- Opa, eu observei que o footer herda a cor da variavel 'bg-background', causando assim, um fundo preto e os hovers dos links deixando o texto deles ficarem com a mesma cor, afetando a ux do usuario.

- Também ajustei os elementos de `a` e de `img` para que, siga boas práticas em usar os componentes que tem as otimizações nativas: `Image` e `Link`.